### PR TITLE
Upgrade to SPI client 2.9.3 for Ramen POS

### DIFF
--- a/ramenpos/Podfile
+++ b/ramenpos/Podfile
@@ -6,7 +6,7 @@ target 'RamenPos' do
     use_frameworks!
     
     # Pods for RamenPos
-    pod 'SPIClient-iOS', '~> 2.9.1'
+    pod 'SPIClient-iOS', '~> 2.9.3'
     # pod 'SPIClient-iOS', :git => 'https://github.com/mx51/spi-client-ios.git', :branch => 'feature/2.9.1'
 
     

--- a/ramenpos/Podfile.lock
+++ b/ramenpos/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - RNCryptor-objc (3.0.6)
   - SocketRocket (0.5.1)
-  - SPIClient-iOS (2.9.1):
+  - SPIClient-iOS (2.9.3):
     - RNCryptor-objc
     - SocketRocket
 
 DEPENDENCIES:
-  - SPIClient-iOS (~> 2.9.1)
+  - SPIClient-iOS (~> 2.9.3)
 
 SPEC REPOS:
   trunk:
@@ -17,8 +17,8 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   RNCryptor-objc: d1b228f9c02e2173df063f0617684c134aed890e
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
-  SPIClient-iOS: c6c3ef701c56d61970dff7b7a49ed3609de4dc18
+  SPIClient-iOS: 67d2e0b6864cb30f80a055ad548e98c714c46fb0
 
-PODFILE CHECKSUM: 076fba70707f373a222299e7f66255a9e0b5d0e1
+PODFILE CHECKSUM: beaadc2d2ac8e2c09775b37fe310fae4fe5ce023
 
 COCOAPODS: 1.11.3

--- a/ramenpos/RamenPos.xcodeproj/project.pbxproj
+++ b/ramenpos/RamenPos.xcodeproj/project.pbxproj
@@ -700,14 +700,14 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 6T5VWZNL33;
 				INFOPLIST_FILE = RamenPos/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.0;
+				MARKETING_VERSION = 2.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.mx51.RamenPOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "RamenPOS prov";
@@ -726,14 +726,14 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 6T5VWZNL33;
 				INFOPLIST_FILE = RamenPos/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.0;
+				MARKETING_VERSION = 2.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.mx51.RamenPOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "RamenPOS prov";


### PR DESCRIPTION
Update SPI client library to 2.9.3 for Ramen POS.

Judging from this PR https://github.com/mx51/spi-samples-ios/pull/35 it seems incrementing CURRENT_PROJECT_VERSION will send out a new build to TestFlight.